### PR TITLE
[PAY-1829] openhtmltopdf lib is red on master

### DIFF
--- a/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/support/NonVisualTestSupport.java
+++ b/openhtmltopdf-examples/src/test/java/com/openhtmltopdf/nonvisualregressiontests/support/NonVisualTestSupport.java
@@ -44,6 +44,17 @@ public class NonVisualTestSupport {
     public NonVisualTestSupport(String baseResourcePath, String outFilePath) {
         this.baseResPath = baseResourcePath;
         this.outPath = outFilePath;
+        createOutputFolderIfNotExists();
+    }
+
+    private void createOutputFolderIfNotExists() {
+        if (!Files.exists(Paths.get(outPath))) {
+            try {
+                Files.createDirectories(Paths.get(outPath));
+            } catch (IOException e) {
+                throw new RuntimeException(e);
+            }
+        }
     }
 
     private void render(


### PR DESCRIPTION
### Context

The build is broken because the output target folder `target/test/visual-tests/test-output` does not exists.
When generating test files (outputing HTML to PDF files), this folder is required to exists first.

<img width="1741" alt="Screenshot 2025-02-05 at 17 44 14" src="https://github.com/user-attachments/assets/05cad36e-2fc3-4ec3-8632-1870d8c53ff6" />

### Changes

We just need to create it if it does not exists.